### PR TITLE
Disable CSRF protection in WebSecurityConfiguration

### DIFF
--- a/backend/src/main/java/com/example/backend/config/WebSecurityConfiguration.java
+++ b/backend/src/main/java/com/example/backend/config/WebSecurityConfiguration.java
@@ -15,6 +15,7 @@ public class WebSecurityConfiguration {
     @Bean
     SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
+                .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/bankAccount/auth/login").permitAll()
                         .anyRequest().authenticated()


### PR DESCRIPTION
CSRF protection was disabled in the WebSecurityConfiguration file. This configuration change will open up all requests for CSRF attacks, so it may pose a security risk if not handled properly elsewhere in the code.